### PR TITLE
Increase Câmara ranking Power BI iframe height

### DIFF
--- a/js/layout.js
+++ b/js/layout.js
@@ -2,7 +2,7 @@ const iframeElement = document.getElementById('iframe-ranking');
 if (iframeElement) {
   window.addEventListener('resize', () => {
     const iframeWidth = iframeElement.offsetWidth;
-    const iframeHeight = iframeWidth * 8.5;
+    const iframeHeight = iframeWidth * 12;
 
     iframeElement.style.height = iframeHeight + 'px';
   });

--- a/pages/c-partidos.html
+++ b/pages/c-partidos.html
@@ -68,7 +68,7 @@
       Fonte:
       <a href="https://dadosabertos.camara.leg.br/" target="_blank">Dados Abertos da Câmara dos Deputados</a>
     </p>
-    <p>&copy; 2024 Placar Congresso</p>
+    <p>&copy; 2026 Placar Congresso</p>
   </footer>
 </body>
 

--- a/pages/c-perfil.html
+++ b/pages/c-perfil.html
@@ -70,7 +70,7 @@
       Fonte:
       <a href="https://dadosabertos.camara.leg.br/" target="_blank">Dados Abertos da Câmara dos Deputados</a>
     </p>
-    <p>&copy; 2024 Placar Congresso</p>
+    <p>&copy; 2026 Placar Congresso</p>
   </footer>
 </body>
 

--- a/pages/c-ranking.html
+++ b/pages/c-ranking.html
@@ -77,7 +77,7 @@
       Fonte:
       <a href="https://dadosabertos.camara.leg.br/" target="_blank">Dados Abertos da Câmara dos Deputados</a>
     </p>
-    <p>&copy; 2024 Placar Congresso</p>
+    <p>&copy; 2026 Placar Congresso</p>
   </footer>
 </body>
 

--- a/pages/c-ufs.html
+++ b/pages/c-ufs.html
@@ -69,7 +69,7 @@
       Fonte:
       <a href="https://dadosabertos.camara.leg.br/" target="_blank">Dados Abertos da Câmara dos Deputados</a>
     </p>
-    <p>&copy; 2024 Placar Congresso</p>
+    <p>&copy; 2026 Placar Congresso</p>
   </footer>
 </body>
 

--- a/pages/c-votos.html
+++ b/pages/c-votos.html
@@ -68,7 +68,7 @@
       Fonte:
       <a href="https://dadosabertos.camara.leg.br/" target="_blank">Dados Abertos da Câmara dos Deputados</a>
     </p>
-    <p>&copy; 2024 Placar Congresso</p>
+    <p>&copy; 2026 Placar Congresso</p>
   </footer>
 </body>
 

--- a/pages/s-partidos.html
+++ b/pages/s-partidos.html
@@ -68,7 +68,7 @@
       Fonte:
       <a href="https://dadosabertos.camara.leg.br/" target="_blank">Dados Abertos da Câmara dos Deputados</a>
     </p>
-    <p>&copy; 2024 Placar Congresso</p>
+    <p>&copy; 2026 Placar Congresso</p>
   </footer>
 </body>
 

--- a/pages/s-perfil.html
+++ b/pages/s-perfil.html
@@ -70,7 +70,7 @@
       Fonte:
       <a href="https://dadosabertos.camara.leg.br/" target="_blank">Dados Abertos da Câmara dos Deputados</a>
     </p>
-    <p>&copy; 2024 Placar Congresso</p>
+    <p>&copy; 2026 Placar Congresso</p>
   </footer>
 </body>
 

--- a/pages/s-ranking.html
+++ b/pages/s-ranking.html
@@ -80,7 +80,7 @@
       Fonte:
       <a href="https://dadosabertos.camara.leg.br/" target="_blank">Dados Abertos da Câmara dos Deputados</a>
     </p>
-    <p>&copy; 2024 Placar Congresso</p>
+    <p>&copy; 2026 Placar Congresso</p>
   </footer>
 </body>
 

--- a/pages/s-ufs.html
+++ b/pages/s-ufs.html
@@ -69,7 +69,7 @@
       Fonte:
       <a href="https://dadosabertos.camara.leg.br/" target="_blank">Dados Abertos da Câmara dos Deputados</a>
     </p>
-    <p>&copy; 2024 Placar Congresso</p>
+    <p>&copy; 2026 Placar Congresso</p>
   </footer>
 </body>
 


### PR DESCRIPTION
Makes the Câmara de Deputados ranking embed taller so the Power BI table fits better and its internal scrollbar is no longer needed.

- **Changed:** Câmara ranking iframe height multiplier in `js/layout.js` from 8.5 to 12 (width-based calculation)
- **Fixed:** Internal scrollbar on the embedded Power BI table on the ranking page