### PR TITLE
Fix Power BI iframe height to eliminate internal scrollbar

### DIFF
--- a/js/layout.js
+++ b/js/layout.js
@@ -2,7 +2,10 @@ const iframeElement = document.getElementById('iframe-ranking');
 if (iframeElement) {
   window.addEventListener('resize', () => {
     const iframeWidth = iframeElement.offsetWidth;
-    const iframeHeight = iframeWidth * 9.2;
+    // Power BI report canvas is 1050px wide × 9950px tall. Match that aspect
+    // ratio so the report fits to width and the iframe is exactly tall enough,
+    // avoiding Power BI's own internal vertical scrollbar.
+    const iframeHeight = iframeWidth * (9950 / 1050);
 
     iframeElement.style.height = iframeHeight + 'px';
   });


### PR DESCRIPTION
## Summary

Updates the iframe height calculation in `js/layout.js` to match the actual Power BI report canvas dimensions (1050×9950px), replacing the hardcoded `9.2` multiplier with the precise aspect ratio `9950/1050`.

This eliminates the internal vertical scrollbar that Power BI was rendering inside the iframe when the height was slightly off.

## Changes

- `js/layout.js`: Replace `iframeWidth * 9.2` with `iframeWidth * (9950 / 1050)` in the resize event handler